### PR TITLE
feat: Add --output-dir flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 *.tgz
+scratch/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "rulegen-ai",
+  "version": "1.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rulegen-ai",
+      "version": "1.1.1",
+      "license": "MIT",
+      "bin": {
+        "rule-gen": "bin/rule-gen.js",
+        "rulegen-ai": "bin/rule-gen.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -23,6 +23,7 @@ Arguments:
 Options:
   --format <format>   Output format: cursor (default), claude-md, agents-md, copilot, windsurf
   --model <model>     Gemini model (default: gemini-2.5-flash)
+  --output-dir <dir>  Directory to write rules to (default: project directory)
   --dry-run           Preview rules without writing files
   --verbose           Show which files are sent to Gemini
   --max-files <n>     Max source files to include (default: 50)
@@ -39,11 +40,12 @@ Examples:
   npx rule-gen --model gemini-2.5-pro   # Use Pro for higher quality
 `.trim();
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const opts = {
     path: '.',
     format: 'cursor',
     model: 'gemini-2.5-flash',
+    outputDir: null,
     dryRun: false,
     verbose: false,
     maxFiles: 50,
@@ -64,6 +66,9 @@ function parseArgs(argv) {
         break;
       case '--model':
         opts.model = argv[++i];
+        break;
+      case '--output-dir':
+        opts.outputDir = argv[++i];
         break;
       case '--dry-run':
         opts.dryRun = true;
@@ -174,7 +179,8 @@ export async function main(argv) {
       console.log('');
     }
   } else {
-    const written = await writer.write(rules, projectPath, opts.format);
+    const outputDir = opts.outputDir ? resolve(opts.outputDir) : projectPath;
+    const written = await writer.write(rules, outputDir, opts.format);
     console.log(`\nWritten ${written.length} files:`);
     for (const f of written) {
       console.log(`  ✓ ${f}`);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { resolve } from 'node:path';
+import { parseArgs } from '../src/cli.js';
+
+describe('CLI --output-dir flag', () => {
+  it('should parse --output-dir and store in outputDir', () => {
+    const opts = parseArgs(['--output-dir', '/tmp/rules']);
+    assert.strictEqual(opts.outputDir, '/tmp/rules');
+  });
+
+  it('should default outputDir to null when not specified', () => {
+    const opts = parseArgs([]);
+    assert.strictEqual(opts.outputDir, null);
+  });
+
+  it('should handle --output-dir with relative path', () => {
+    const opts = parseArgs(['--output-dir', './custom-output']);
+    assert.strictEqual(opts.outputDir, './custom-output');
+  });
+
+  it('should coexist with other flags', () => {
+    const opts = parseArgs(['--format', 'claude-md', '--output-dir', '/tmp/out', '--dry-run', '.']);
+    assert.strictEqual(opts.format, 'claude-md');
+    assert.strictEqual(opts.outputDir, '/tmp/out');
+    assert.strictEqual(opts.dryRun, true);
+    assert.strictEqual(opts.path, '.');
+  });
+});


### PR DESCRIPTION
Add `--output-dir <dir>` flag to write generated rules to a custom directory instead of the project directory.

- Flag parsed in CLI, resolved to absolute path at write time
- Defaults to project path when not specified
- `parseArgs` exported for testability
- 4 tests covering parsing, defaults, relative paths, flag coexistence

Closes #5